### PR TITLE
Remove parentheses from Macro

### DIFF
--- a/deepdrr/projector/project_kernel.cu
+++ b/deepdrr/projector/project_kernel.cu
@@ -52,59 +52,59 @@ texture<float, 3, cudaReadModeElementType> seg(12);
 texture<float, 3, cudaReadModeElementType> seg(13);
 #endif
 
-#define UPDATE(multiplier, n) ({\
+#define UPDATE(multiplier, n) {\
     output[idx + (n)] += (multiplier) * tex3D(volume, px, py, pz) * round(cubicTex3D(seg(n), px, py, pz));\
-})
+}
 
 #if NUM_MATERIALS == 1
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
-})
+}
 #elif NUM_MATERIALS == 2
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
-})
+}
 #elif NUM_MATERIALS == 3
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
-})
+}
 #elif NUM_MATERIALS == 4
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
     UPDATE(multiplier, 3);\
-})
+}
 #elif NUM_MATERIALS == 5
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
     UPDATE(multiplier, 3);\
     UPDATE(multiplier, 4);\
-})
+}
 #elif NUM_MATERIALS == 6
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
     UPDATE(multiplier, 4);\
     UPDATE(multiplier, 5);\
-})  
+}
 #elif NUM_MATERIALS == 7
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
     UPDATE(multiplier, 4);\
     UPDATE(multiplier, 5);\
     UPDATE(multiplier, 6);\
-})
+}
 #elif NUM_MATERIALS == 8
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -112,9 +112,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 5);\
     UPDATE(multiplier, 6);\
     UPDATE(multiplier, 7);\
-})
+}
 #elif NUM_MATERIALS == 9
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -123,9 +123,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 6);\
     UPDATE(multiplier, 7);\
     UPDATE(multiplier, 8);\
-})
+}
 #elif NUM_MATERIALS == 10
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -135,9 +135,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 7);\
     UPDATE(multiplier, 8);\
     UPDATE(multiplier, 9);\
-})
+}
 #elif NUM_MATERIALS == 11
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -148,9 +148,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 8);\
     UPDATE(multiplier, 9);\
     UPDATE(multiplierl, 10);\
-})
+}
 #elif NUM_MATERIALS == 12
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -162,9 +162,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 9);\
     UPDATE(multiplier, 10);\
     UPDATE(multiplier, 11);\
-})
+}
 #elif NUM_MATERIALS == 13
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -177,9 +177,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 10);\
     UPDATE(multiplier, 11);\
     UPDATE(multiplier, 12);\
-})
+}
 #elif NUM_MATERIALS == 14
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -193,11 +193,11 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 11);\
     UPDATE(multiplier, 12);\
     UPDATE(multiplier, 13);\
-})
+}
 #else
 #define INTERPOLATE(multiplier) {\
     fprintf(stderr, "NUM_MATERIALS not in [1, 14]");\
-)
+}
 #endif
 
 // the CT volume (used to be tex_density)


### PR DESCRIPTION
The parenthesis in the macros UPDATE and INTERPOLATE are causing problems when compiling on windows.
After macro resolution both the parentheses and the curly brackets are fed into compilation, which at least on 
my build causes problems.

See https://github.com/arcadelab/deepdrr/issues/26 for more details.

Please test this change on Linux before merging.

Fixes #26 