### PR TITLE
vol.load_dicom() implementation

### DIFF
--- a/deepdrr/projector/project_kernel.cu
+++ b/deepdrr/projector/project_kernel.cu
@@ -52,59 +52,59 @@ texture<float, 3, cudaReadModeElementType> seg(12);
 texture<float, 3, cudaReadModeElementType> seg(13);
 #endif
 
-#define UPDATE(multiplier, n) ({\
+#define UPDATE(multiplier, n) {\
     output[idx + (n)] += (multiplier) * tex3D(volume, px, py, pz) * round(cubicTex3D(seg(n), px, py, pz));\
-})
+}
 
 #if NUM_MATERIALS == 1
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
-})
+}
 #elif NUM_MATERIALS == 2
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
-})
+}
 #elif NUM_MATERIALS == 3
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
-})
+}
 #elif NUM_MATERIALS == 4
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
     UPDATE(multiplier, 3);\
-})
+}
 #elif NUM_MATERIALS == 5
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
     UPDATE(multiplier, 3);\
     UPDATE(multiplier, 4);\
-})
+}
 #elif NUM_MATERIALS == 6
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
     UPDATE(multiplier, 4);\
     UPDATE(multiplier, 5);\
-})  
+}
 #elif NUM_MATERIALS == 7
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
     UPDATE(multiplier, 4);\
     UPDATE(multiplier, 5);\
     UPDATE(multiplier, 6);\
-})
+}
 #elif NUM_MATERIALS == 8
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -112,9 +112,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 5);\
     UPDATE(multiplier, 6);\
     UPDATE(multiplier, 7);\
-})
+}
 #elif NUM_MATERIALS == 9
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -123,9 +123,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 6);\
     UPDATE(multiplier, 7);\
     UPDATE(multiplier, 8);\
-})
+}
 #elif NUM_MATERIALS == 10
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -135,9 +135,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 7);\
     UPDATE(multiplier, 8);\
     UPDATE(multiplier, 9);\
-})
+}
 #elif NUM_MATERIALS == 11
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -148,9 +148,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 8);\
     UPDATE(multiplier, 9);\
     UPDATE(multiplierl, 10);\
-})
+}
 #elif NUM_MATERIALS == 12
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -162,9 +162,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 9);\
     UPDATE(multiplier, 10);\
     UPDATE(multiplier, 11);\
-})
+}
 #elif NUM_MATERIALS == 13
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -177,9 +177,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 10);\
     UPDATE(multiplier, 11);\
     UPDATE(multiplier, 12);\
-})
+}
 #elif NUM_MATERIALS == 14
-#define INTERPOLATE(multiplier) ({\
+#define INTERPOLATE(multiplier) {\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -193,11 +193,11 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 11);\
     UPDATE(multiplier, 12);\
     UPDATE(multiplier, 13);\
-})
+}
 #else
 #define INTERPOLATE(multiplier) {\
     fprintf(stderr, "NUM_MATERIALS not in [1, 14]");\
-)
+}
 #endif
 
 // the CT volume (used to be tex_density)

--- a/deepdrr/projector/project_kernel.cu
+++ b/deepdrr/projector/project_kernel.cu
@@ -52,59 +52,59 @@ texture<float, 3, cudaReadModeElementType> seg(12);
 texture<float, 3, cudaReadModeElementType> seg(13);
 #endif
 
-#define UPDATE(multiplier, n) {\
+#define UPDATE(multiplier, n) ({\
     output[idx + (n)] += (multiplier) * tex3D(volume, px, py, pz) * round(cubicTex3D(seg(n), px, py, pz));\
-}
+})
 
 #if NUM_MATERIALS == 1
-#define INTERPOLATE(multiplier) {\
+#define INTERPOLATE(multiplier) ({\
     UPDATE(multiplier, 0);\
-}
+})
 #elif NUM_MATERIALS == 2
-#define INTERPOLATE(multiplier) {\
+#define INTERPOLATE(multiplier) ({\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
-}
+})
 #elif NUM_MATERIALS == 3
-#define INTERPOLATE(multiplier) {\
+#define INTERPOLATE(multiplier) ({\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
-}
+})
 #elif NUM_MATERIALS == 4
-#define INTERPOLATE(multiplier) {\
+#define INTERPOLATE(multiplier) ({\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
     UPDATE(multiplier, 3);\
-}
+})
 #elif NUM_MATERIALS == 5
-#define INTERPOLATE(multiplier) {\
+#define INTERPOLATE(multiplier) ({\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
     UPDATE(multiplier, 3);\
     UPDATE(multiplier, 4);\
-}
+})
 #elif NUM_MATERIALS == 6
-#define INTERPOLATE(multiplier) {\
+#define INTERPOLATE(multiplier) ({\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
     UPDATE(multiplier, 4);\
     UPDATE(multiplier, 5);\
-}
+})  
 #elif NUM_MATERIALS == 7
-#define INTERPOLATE(multiplier) {\
+#define INTERPOLATE(multiplier) ({\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
     UPDATE(multiplier, 4);\
     UPDATE(multiplier, 5);\
     UPDATE(multiplier, 6);\
-}
+})
 #elif NUM_MATERIALS == 8
-#define INTERPOLATE(multiplier) {\
+#define INTERPOLATE(multiplier) ({\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -112,9 +112,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 5);\
     UPDATE(multiplier, 6);\
     UPDATE(multiplier, 7);\
-}
+})
 #elif NUM_MATERIALS == 9
-#define INTERPOLATE(multiplier) {\
+#define INTERPOLATE(multiplier) ({\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -123,9 +123,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 6);\
     UPDATE(multiplier, 7);\
     UPDATE(multiplier, 8);\
-}
+})
 #elif NUM_MATERIALS == 10
-#define INTERPOLATE(multiplier) {\
+#define INTERPOLATE(multiplier) ({\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -135,9 +135,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 7);\
     UPDATE(multiplier, 8);\
     UPDATE(multiplier, 9);\
-}
+})
 #elif NUM_MATERIALS == 11
-#define INTERPOLATE(multiplier) {\
+#define INTERPOLATE(multiplier) ({\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -148,9 +148,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 8);\
     UPDATE(multiplier, 9);\
     UPDATE(multiplierl, 10);\
-}
+})
 #elif NUM_MATERIALS == 12
-#define INTERPOLATE(multiplier) {\
+#define INTERPOLATE(multiplier) ({\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -162,9 +162,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 9);\
     UPDATE(multiplier, 10);\
     UPDATE(multiplier, 11);\
-}
+})
 #elif NUM_MATERIALS == 13
-#define INTERPOLATE(multiplier) {\
+#define INTERPOLATE(multiplier) ({\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -177,9 +177,9 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 10);\
     UPDATE(multiplier, 11);\
     UPDATE(multiplier, 12);\
-}
+})
 #elif NUM_MATERIALS == 14
-#define INTERPOLATE(multiplier) {\
+#define INTERPOLATE(multiplier) ({\
     UPDATE(multiplier, 0);\
     UPDATE(multiplier, 1);\
     UPDATE(multiplier, 2);\
@@ -193,11 +193,11 @@ texture<float, 3, cudaReadModeElementType> seg(13);
     UPDATE(multiplier, 11);\
     UPDATE(multiplier, 12);\
     UPDATE(multiplier, 13);\
-}
+})
 #else
 #define INTERPOLATE(multiplier) {\
     fprintf(stderr, "NUM_MATERIALS not in [1, 14]");\
-}
+)
 #endif
 
 // the CT volume (used to be tex_density)

--- a/deepdrr/vol.py
+++ b/deepdrr/vol.py
@@ -162,24 +162,23 @@ class Volume(object):
     def from_dicom(
             cls,
             path: Path,
-            origin: geo.Point3D = None,
             use_thresholding: bool = True,
             world_from_anatomical: Optional[geo.FrameTransform] = None,
             use_cached: bool = True,
             cache_dir: Optional[Path] = None
     ):
         """
-        load a volume from a dicom file and set the anatomical_from_ijk transform from metadata
+        load a volume from a dicom file and compute the anatomical_from_ijk transform from metadata
         https://www.slicer.org/wiki/Coordinate_systems
         Args:
-            path:
-            use_thresholding:
-            world_from_anatomical:
-            use_cached:
-            cache_dir:
+            path: path-like to a multi-frame dicom file. (Currently only Multi-Frame from Siemens supported)
+            use_thresholding (bool, optional): segment the materials using thresholding (faster but less accurate). Defaults to True.
+            world_from_anatomical (Optional[geo.FrameTransform], optional): position the volume in world space. If None, uses identity. Defaults to None.
+            use_cached (bool, optional): [description]. Use a cached segmentation if available. Defaults to True.
+            cache_dir (Optional[Path], optional): Where to load/save the cached segmentation. If None, use the parent dir of `path`. Defaults to None.
 
         Returns:
-
+            Volume: an instance of a deepdrr volume
         """
         path = Path(path)
         stem = path.name.split('.')[0]
@@ -253,7 +252,6 @@ class Volume(object):
                 np.savez(materials_path, **materials)
 
         # manually composing affine transform lps_from_ijk
-
         # construct column for index k
         k = np.array((last_slice_position - first_slice_position) / num_slices).reshape(3, 1)
 


### PR DESCRIPTION
Hey there! As discussed, I started working on the `vol.load_dicom()` feature. 

It now works for the datasets I work with, but extracting the affine transform from DICOM metadata is no easy feat. There are whole specialized libraries trying to provide an easy nifti-like interface to DICOM images. See [this issue](https://github.com/nipy/nibabel/issues/977) for example.

In this draft-pull-request, I offer you to integrate the solution that I tested against MultiFrame-Dicom volumes from a Siemens Cios Spin-System.

From a design point-of-view it might be more sensible to outsource the task to a library that specializes on this. For example [nibabel ](https://github.com/nipy/nibabel) or [medio](https://github.com/RSIP-Vision/medio).

As you can see in [this commit](https://github.com/maxrohleder/deepdrr/commit/2036aef1df89d2e2989608a0cafb3b264dfd01ea), I already tried to use the `nibabel.nicom.dicomwrappers.MultiframeWrapperclass`. With a test dataset I used, It failed to correctly calculate the lps_from_ijk transform. However, in the [thread about this issue](https://github.com/nipy/nibabel/issues/977#issuecomment-811004821) it sounds like we can expect an update with this functionality.

Kind regards, 
Max