### PR TITLE
Fix case with no air in volume but att outside

### DIFF
--- a/deepdrr/projector/projector.py
+++ b/deepdrr/projector/projector.py
@@ -292,6 +292,9 @@ class Projector(object):
         for _vol in self.volumes:
             all_mats.extend(list(_vol.materials.keys()))
 
+        if attenuate_outside_volume:
+            all_mats.append("air")
+            
         self.all_materials = list(set(all_mats))
         self.all_materials.sort()
         log.debug(f"MATERIALS: {self.all_materials}")


### PR DESCRIPTION
Air should be added to the set of materials if attenuate_outside_volume is enabled