### PR TITLE
Small fixes

### DIFF
--- a/deepdrr/projector/projector.py
+++ b/deepdrr/projector/projector.py
@@ -859,7 +859,7 @@ class Projector(object):
             self.cam.cx = proj.intrinsic.cx
             self.cam.cy = proj.intrinsic.cy
             self.cam.znear = 1  # self.device.source_to_detector_distance / 1000
-            self.cam.zfar = self.device.source_to_detector_distance * 4
+            self.cam.zfar = self.source_to_detector_distance * 4
 
             deepdrr_to_opengl_cam = np.array(
                 [
@@ -872,7 +872,7 @@ class Projector(object):
 
             self.cam_node.matrix = np.array(proj.extrinsic.inv) @ deepdrr_to_opengl_cam
 
-            zfar = self.device.source_to_detector_distance * 2 * 4  # TODO (liam)
+            zfar = self.source_to_detector_distance * 2 * 4  # TODO (liam)
 
         return zfar
 
@@ -1166,7 +1166,7 @@ class Projector(object):
                     * NUMBYTES_INT8
                 ),
                 np.int32(total_pixels),
-                np.float32(self.device.source_to_detector_distance * 2),
+                np.float32(self.source_to_detector_distance * 2),
             ),
             block=(32, 1, 1),  # TODO (liam)
             grid=(2048, 1),  # TODO (liam)
@@ -1363,8 +1363,8 @@ class Projector(object):
         log.debug(f"beginning call to Projector.initialize")
         init_tick = time.perf_counter()
 
-        width = self.device.sensor_width
-        height = self.device.sensor_height
+        width = self.camera_intrinsics.sensor_width
+        height = self.camera_intrinsics.sensor_height
         total_pixels = width * height
 
         device_id = int(os.environ.get("EGL_DEVICE_ID", "0"))
@@ -1469,16 +1469,16 @@ class Projector(object):
             self.mesh_nodes.append(node)
             self.scene.add(drrmesh.mesh, parent_node=node)
 
-        cam_intr = self.device.camera_intrinsics
+        cam_intr = self.camera_intrinsics
 
         self.cam = IntrinsicsCamera(
             fx=cam_intr.fx,
             fy=cam_intr.fy,
             cx=cam_intr.cx,
             cy=cam_intr.cy,
-            znear=self.device.source_to_detector_distance
+            znear=self.source_to_detector_distance
             / 1000,  # TODO (liam) near clipping plane parameter
-            zfar=self.device.source_to_detector_distance,
+            zfar=self.source_to_detector_distance,
         )
 
         self.cam_node = self.scene.add(self.cam)

--- a/deepdrr/utils/image_utils.py
+++ b/deepdrr/utils/image_utils.py
@@ -40,18 +40,18 @@ def _neglog(image: np.ndarray, epsilon: float = 0.01) -> np.ndarray:
     image_min = image.min(axis=(1, 2), keepdims=True)
     image_max = image.max(axis=(1, 2), keepdims=True)
     if np.any(image_max == image_min):
-        logger.debug(
+        log.debug(
             f"mapping constant image to 0. This probably indicates the projector is pointed away from the volume."
         )
         # TODO(killeen): for multiple images, only fill the bad ones
         image[:] = 0
         if image.shape[0] > 1:
-            logger.error("TODO: zeroed all images, even though only one might be bad.")
+            log.error("TODO: zeroed all images, even though only one might be bad.")
     else:
         image = (image - image_min) / (image_max - image_min)
 
     if np.any(np.isnan(image)):
-        logger.warning(f"got NaN values from negative log transform.")
+        log.warning(f"got NaN values from negative log transform.")
 
     if len(shape) == 2:
         return image[0]


### PR DESCRIPTION
Projector couldn't actually be used without specifying device as several parts of the code relied on device for sensor dimensions and source to detector distance.
Instead, Projector now use its methods source_to_detector_distance and sensor_width, sensor_height, which default to device if device is set.
Also fix a wrong variable name for the logger in image_utils.py